### PR TITLE
Refactor and fix user filter logic

### DIFF
--- a/tests/test_filter_logic.py
+++ b/tests/test_filter_logic.py
@@ -83,7 +83,7 @@ def test_generate_user_pairs(users, expected_user_pairs):
 @pytest.mark.parametrize(
     "users,previous_runs,expected_raises,expected_filtered_users",
     [
-        # Simplest cases, no previous runs and number of uses is a multiple of
+        # Simplest cases, no previous runs and number of users is a multiple of
         # 2, the filtered users should be 50% of the total users
         [
             ["a", "b"],

--- a/tests/test_filter_logic.py
+++ b/tests/test_filter_logic.py
@@ -1,7 +1,11 @@
+import random
+import pytest
+
+from contextlib import nullcontext as does_not_raise
 from freezegun import freeze_time
 
 # Assuming the filter_users_based_on_previous_runs function is in the 'main' module
-from slack_bot.app import filter_users_based_on_previous_runs
+from slack_bot.app import filter_users_based_on_previous_runs, generate_user_pairs
 
 
 @freeze_time("2023-08-01")
@@ -52,3 +56,146 @@ def test_filter_users_correct_number_with_all_have_history():
 
     # then
     assert len(taking_break) == 6
+
+
+@pytest.mark.parametrize(
+    "users,expected_user_pairs",
+    [
+        [
+            ["a", "b", "c", "d"],
+            [("a", "b"), ("c", "d")],
+        ],
+        [
+            ["a", "d", "c", "b"],
+            [("a", "d"), ("b", "c")],
+        ],
+        [
+            ["a", "b", "c", "d", "e"],
+            [("a", "b"), ("c", "d")],
+        ],
+    ],
+)
+def test_generate_user_pairs(users, expected_user_pairs):
+    user_pairs = generate_user_pairs(users)
+    assert user_pairs == expected_user_pairs
+
+
+@pytest.mark.parametrize(
+    "users,previous_runs,expected_raises,expected_filtered_users",
+    [
+        # Simplest cases, no previous runs and number of uses is a multiple of
+        # 2, the filtered users should be 50% of the total users
+        [
+            ["a", "b"],
+            [],
+            does_not_raise(),
+            ["a", "b"],
+        ],
+        [
+            ["a", "b", "c", "d"],
+            [],
+            does_not_raise(),
+            ["c", "a"],
+        ],
+        [
+            ["a", "b", "c", "d", "e", "f", "g", "h"],
+            [],
+            does_not_raise(),
+            ["e", "f", "b", "c"],
+        ],
+        # A few cases for even numbers of users
+        [
+            ["a", "b", "c", "d", "e", "f"],
+            [],
+            does_not_raise(),
+            ["e", "b", "c", "a"],
+        ],
+        [
+            ["a", "b", "c", "d", "e", "f", "g",  "h", "i", "j"],
+            [],
+            does_not_raise(),
+            ["f", "h", "e", "i", "d", "b"],
+        ],
+        # A few cases for odd numbers of users
+        [
+            ["a", "b", "c"],
+            [],
+            does_not_raise(),
+            ["c", "a"],
+        ],
+        [
+            ["a", "b", "c", "d", "e"],
+            [],
+            does_not_raise(),
+            ["c", "a", "b", "e"],
+        ],
+        [
+            ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            [],
+            does_not_raise(),
+            ["c", "h", "e", "f", "b", "d"],
+        ],
+        [
+            ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+            [],
+            does_not_raise(),
+            ["b", "i", "c", "d", "j", "f"],
+        ],
+        # Some users have been chosen last time, pairs should only be created
+        # from new users
+        [
+            ["a", "b", "c", "d", "e", "f", "g", "h"],
+            [
+                {"date": "2023-07-02", "pair": ["a", "b"]},
+                {"date": "2023-07-02", "pair": ["c", "d"]},
+            ],
+            does_not_raise(),
+            ["g", "e", "h", "f"],
+        ],
+        # "b" is the only needed user, "a", "c" and "e" are filled randomly to
+        # reach 50%. The only valid pair for "a" is (a, b) and therefore the
+        # other pair is (c, e).
+        [
+            ["a", "b", "c", "d", "e"],
+            [
+                {"date": "2023-07-02", "pair": ["a", "c"]},
+                {"date": "2023-07-02", "pair": ["a", "e"]},
+                {"date": "2023-07-02", "pair": ["c", "d"]},
+            ],
+            does_not_raise(),
+            ["b", "a", "e", "c"],
+        ],
+        # No valid pair, as only (a, b) is possible but was used last time
+        [
+            ["a", "b"],
+            [
+                {"date": "2023-07-02", "pair": ["a", "b"]},
+            ],
+            pytest.raises(ValueError),
+            [],
+        ],
+        # Gets stuck in a loop shuffling (b, c), valid would be (a, c). This is
+        # the result of all users being present in the list of previous runs,
+        # which is a valid edge case, but not relevant given that we only
+        # select pairs for 50% of the users every time.
+        [
+            ["a", "b", "c"],
+            [
+                {"date": "2023-07-02", "pair": ["a", "b"]},
+                {"date": "2023-07-02", "pair": ["b", "c"]},
+            ],
+            pytest.raises(ValueError),
+            [],
+        ],
+    ],
+)
+def test_filter_users_based_on_previous_runs_no_duplicates(
+    users,
+    previous_runs,
+    expected_raises,
+    expected_filtered_users
+):
+    random.seed(0)
+    with expected_raises:
+        filtered_users = filter_users_based_on_previous_runs(users, previous_runs)
+        assert filtered_users == expected_filtered_users


### PR DESCRIPTION
# Changes

Es gab einen Bug, dass gleiche Userpaare mehrmals hintereinander ausgelost werden konnten. Dieser enstand dadurch, dass die Logik zum Bilden der Paare in `filter_users_based_on_previous_runs` anders war als in `process_users`.

Es gibt jetzt eine kleine Funktion, um aus der Liste der User die Paare zu bilden, damit diese einzeln getestet und wiederverwendet werden kann.

Ich hab einige Test-Cases hinzugefügt, die explizit prüfen, ob erwartete gefilterte Userlisten zurückgegeben werden. Beim schreiben dieser Test-Cases ist mir aufgefallen, dass die Filterfunktion unter bestimmten Bedingungen in eine Endlosschlaufe laufen kann. Ich hab dafür eine maximale Iterationszahl eingebaut. Idealerweise müsste man die Logik umschreiben, so dass nicht die Liste geshuffled wird, bis man ein passendes Ergebnis bekommt, sondern sich alle möglichen Paare bildet und daraus eine Auswahl trifft. Das ist aber nicht nötig, solange wir nur eine Auswahl aller User jedes mal auslosen, dann tritt der Fall nicht auf 🙂

