### PR TITLE
Improvements for parental leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can find the token in the `OAuth & Permissions` section of your app.
 You also need to configure the user list in the SecretsManager. 
 Create a secret named `coffee-break-slack-bot/users` to store the user list.
 You can find the id of a slack member in the profile information. Press `More` and copy the member id.
-The format of the list has to be `["U1", "U2", ...]`.
+The format of the list has to be `{username1: id_1, username2: id_2, ...}`.
 
 ### Terraform Variables
 If you would like to override default values of variables, copy the `terraform.tfvars.dist` file to `terraform.tfvars` and fill in values for the predefined variable names.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ As a result, the exchange in the team is increased.
 Users that are absent are automatically excluded. Absence is determined by checking if one of the following status emojis is set:
 - 🌴
 - 🤒
+- 👶
 
 ## Requirements
 - [Python 3.9](https://www.python.org/)

--- a/slack_bot/app.py
+++ b/slack_bot/app.py
@@ -12,7 +12,7 @@ from slack_sdk import WebClient
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-ABSENCE_EMOJIS = [":palm_tree:", ":face_with_thermometer:"]
+ABSENCE_EMOJIS = [":palm_tree:", ":face_with_thermometer:", ":baby:"]
 
 
 class FileHandler(ABC):

--- a/slack_bot/app.py
+++ b/slack_bot/app.py
@@ -123,7 +123,7 @@ def get_token() -> str:
 
 
 def get_users(client: WebClient) -> list:
-    users = json.loads(os.environ.get("USERS"))
+    users = list(json.loads(os.environ.get("USERS")).values())
     return filter_users(users, client)
 
 


### PR DESCRIPTION
This PR adds a baby emoji to the list of disabling emojis to allow for parental leave.

The AWS secret that defines the list of users has been switched from a list to a dictionary to allow mapping Slack IDs to users.